### PR TITLE
Update to the new versions of structurizr-core and structurizr-export.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,11 +21,8 @@ repositories {
 }
 
 dependencies {
-    api(libs.structurizr.export)  {
-        // TODO remove when https://github.com/structurizr/export/pull/9 is merged and released
-        exclude(module = "structurizr-client")
-    }
-    // TODO remove when https://github.com/structurizr/export/pull/9 is merged and released
+    api(libs.google.findbugs)
+    api(libs.structurizr.export)
     api(libs.structurizr.core)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.assertj)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,15 +2,19 @@
 assertj = "3.23.1"
 junit = "5.8.2"
 
-structurizr = "1.12.2"
-structurizr-export = "1.5.0"
+structurizr = "1.15.2"
+structurizr-export = "1.7.0"
+
+findbugs = "3.0.2"
 
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 
 structurizr-export = { module = "com.structurizr:structurizr-export", version.ref = "structurizr-export" }
-structurizr-core = { module = "com.structurizr:structurizr-core", version.ref = "structurizr" }
+structurizr-core = { module = "com.structurizr:structurizr-client", version.ref = "structurizr" }
 structurizr-client = { module = "com.structurizr:structurizr-client", version.ref = "structurizr" }
+
+google-findbugs = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs" }
 
 architectureicons= {module="io.cloudflight.architectureicons:architectureicons", version="0.3.0"}

--- a/src/main/java/io/cloudflight/structurizr/plantuml/ExtendedC4PlantUmlExporter.java
+++ b/src/main/java/io/cloudflight/structurizr/plantuml/ExtendedC4PlantUmlExporter.java
@@ -41,31 +41,33 @@ public class ExtendedC4PlantUmlExporter extends PatchedC4PlantUMLExporter {
                 .flatMap(elementView -> elementView.getElement().getTagsAsSet().stream())
                 .distinct().forEach(tag -> {
                             ElementStyle style = view.getViewSet().getConfiguration().getStyles().findElementStyle(tag);
-                            Map<String, String> attributes = new LinkedHashMap<>();
-                            if (!isNullOrEmpty(style.getBackground())) {
-                                attributes.put("$bgColor", quote(style.getBackground()));
-                            }
-                            if (!isNullOrEmpty(style.getColor())) {
-                                attributes.put("$fontColor", quote(style.getColor()));
-                            }
-                            if (!isNullOrEmpty(style.getStroke())) {
-                                attributes.put("$borderColor", quote(style.getStroke()));
-                            }
-                            if (style.getShape() == Shape.RoundedBox) {
-                                attributes.put("$shape", "RoundedBoxShape()");
-                            }
-                            if (!isNullOrEmpty(style.getIcon())) {
-                                attributes.put("$sprite", quote("img:" + style.getIcon()));
-                            }
-                            if (!attributes.isEmpty()) {
-                                writer.writeLine(format("AddElementTag(\"%s\", %s)", tag, mapToString(attributes)));
-                            }
-                            if (!isNullOrEmpty(style.getBackground()) && !isNullOrEmpty(style.getColor())) {
-                                if (Tags.PERSON.equals(tag) || Tags.COMPONENT.equals(tag) || Tags.CONTAINER.equals(tag)) {
-                                    // if background and color is set, and this is the element style of one of the default tags
-                                    // when we can call UpdateElementStyle with the lowercase (i.e. UpdateElementStyle("person")) in
-                                    // order to remove this line from the legend
-                                    writer.writeLine(format("UpdateElementStyle(\"%s\")", tag.toLowerCase()));
+                            if (style != null) {
+                                Map<String, String> attributes = new LinkedHashMap<>();
+                                if (!isNullOrEmpty(style.getBackground())) {
+                                    attributes.put("$bgColor", quote(style.getBackground()));
+                                }
+                                if (!isNullOrEmpty(style.getColor())) {
+                                    attributes.put("$fontColor", quote(style.getColor()));
+                                }
+                                if (!isNullOrEmpty(style.getStroke())) {
+                                    attributes.put("$borderColor", quote(style.getStroke()));
+                                }
+                                if (style.getShape() == Shape.RoundedBox) {
+                                    attributes.put("$shape", "RoundedBoxShape()");
+                                }
+                                if (!isNullOrEmpty(style.getIcon())) {
+                                    attributes.put("$sprite", quote("img:" + style.getIcon()));
+                                }
+                                if (!attributes.isEmpty()) {
+                                    writer.writeLine(format("AddElementTag(\"%s\", %s)", tag, mapToString(attributes)));
+                                }
+                                if (!isNullOrEmpty(style.getBackground()) && !isNullOrEmpty(style.getColor())) {
+                                    if (Tags.PERSON.equals(tag) || Tags.COMPONENT.equals(tag) || Tags.CONTAINER.equals(tag)) {
+                                        // if background and color is set, and this is the element style of one of the default tags
+                                        // when we can call UpdateElementStyle with the lowercase (i.e. UpdateElementStyle("person")) in
+                                        // order to remove this line from the legend
+                                        writer.writeLine(format("UpdateElementStyle(\"%s\")", tag.toLowerCase()));
+                                    }
                                 }
                             }
                         }
@@ -74,18 +76,20 @@ public class ExtendedC4PlantUmlExporter extends PatchedC4PlantUMLExporter {
                 .flatMap(relationshipView -> relationshipView.getRelationship().getTagsAsSet().stream())
                 .distinct().forEach(tag -> {
                             RelationshipStyle style = view.getViewSet().getConfiguration().getStyles().findRelationshipStyle(tag);
-                            Map<String, String> attributes = new LinkedHashMap<>();
-                            if (!isNullOrEmpty(style.getColor())) {
-                                attributes.put("$lineColor", quote(style.getColor()));
-                                attributes.put("$textColor", quote(style.getColor()));
-                            }
-                            if (style.getStyle() == LineStyle.Dashed) {
-                                attributes.put("$lineStyle", "DashedLine()");
-                            } else if (style.getStyle() == LineStyle.Dotted) {
-                                attributes.put("$lineStyle", "DottedLine()");
-                            }
-                            if (!attributes.isEmpty()) {
-                                writer.writeLine(format("AddRelTag(\"%s\", %s)", tag, mapToString(attributes)));
+                            if (style != null) {
+                                Map<String, String> attributes = new LinkedHashMap<>();
+                                if (!isNullOrEmpty(style.getColor())) {
+                                    attributes.put("$lineColor", quote(style.getColor()));
+                                    attributes.put("$textColor", quote(style.getColor()));
+                                }
+                                if (style.getStyle() == LineStyle.Dashed) {
+                                    attributes.put("$lineStyle", "DashedLine()");
+                                } else if (style.getStyle() == LineStyle.Dotted) {
+                                    attributes.put("$lineStyle", "DottedLine()");
+                                }
+                                if (!attributes.isEmpty()) {
+                                    writer.writeLine(format("AddRelTag(\"%s\", %s)", tag, mapToString(attributes)));
+                                }
                             }
                         }
                 );


### PR DESCRIPTION
This PR updates the `structurizr-core` and `structurizr-export` dependencies. The `Styles.findElementStyle(tag)` and `Styles.findRelationshipStyle(tag)` methods can now return null, which breaks the tests, so this has been fixed too. If you'd like your exporter bundled into the CLI, just let me know when you release a new version to Maven Central and I'll add it to the CLI.